### PR TITLE
feat(backend): add campaign and saved message data models

### DIFF
--- a/backend/app/models/campaign_models.py
+++ b/backend/app/models/campaign_models.py
@@ -1,0 +1,53 @@
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import datetime
+from enum import Enum
+
+class CampaignStatus(str, Enum):
+    TASLAK = "Taslak"
+    AKTIF = "Aktif"
+    PLANLANDI = "Planlandı"
+    TAMAMLANDI = "Tamamlandı"
+
+class CampaignBase(BaseModel):
+    name: str
+    start_date: datetime
+    end_date: datetime
+    products: List[str]
+    discount_rate: Optional[float] = 0.0
+
+class CampaignCreate(CampaignBase):
+    customer_id: str
+
+class CampaignUpdate(BaseModel):
+    name: Optional[str] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    products: Optional[List[str]] = None
+    discount_rate: Optional[float] = None
+    status: Optional[CampaignStatus] = None
+
+class Campaign(CampaignBase):
+    id: str
+    customer_id: str
+    user_id: str
+    status: CampaignStatus = CampaignStatus.TASLAK
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+class SavedMessageBase(BaseModel):
+    content: str
+    target_audience: str
+
+class SavedMessageCreate(SavedMessageBase):
+    pass
+
+class SavedMessage(SavedMessageBase):
+    id: str
+    campaign_id: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## 📌 Summary
Created Pydantic models for campaigns and saved SMS messages to support campaign management feature.

## 🔗 Related Issue
Closes #63 

## 🧠 What was done?
- [x] Created `app/models/campaign_models.py`
- [x] Defined `CampaignBase` model (name, start_date, end_date, products, discount_rate)
- [x] Defined `CampaignCreate` model (extends CampaignBase with customer_id)
- [x] Defined `CampaignUpdate` model (optional fields)
- [x] Defined `Campaign` model (includes id, customer_id, user_id, status, created_at)
- [x] Defined `SavedMessage` and `SavedMessageCreate` models
- [x] Created `CampaignStatus` enum (Taslak, Aktif, Planlandı, Tamamlandı)

## 🔧 Technical Details
**New File:** `app/models/campaign_models.py`

**Model Structure:**
- `CampaignStatus`: Enum with values taslak, aktif, planlandı, tamamlandı
- `Campaign`: Full model with all fields for Firestore storage
- `SavedMessage`: Stores individual saved SMS drafts per campaign

## 🧪 How was it tested?
- [x] Models import without errors
- [x] Type hints validated
- [x] Pydantic validation works for required fields
- [x] Status enum values work correctly

## 📂 Affected Areas
- [x] Backend - Models

## ✅ Checklist
- [ ] BRANCHING.md kurallarına uygun branch kullandım (`feature/backend-campaign-models`)
- [ ] CODING_STANDARDS.md kurallarına uygun kod yazdım
- [ ] Type hints are complete
- [ ] All acceptance criteria from issue #63  met