### PR TITLE
Fix/customer sorting persistence

### DIFF
--- a/backend/app/services/customer_service.py
+++ b/backend/app/services/customer_service.py
@@ -77,7 +77,7 @@ class CustomerService:
             customers.append(Customer(**data))
         
         # Sort in-memory instead
-        customers.sort(key=lambda x: x.created_at, reverse=True)
+        customers.sort(key=lambda x: x.created_at)
         return customers
 
     def get_customer(self, customer_id: str, user_id: str) -> Optional[Customer]:


### PR DESCRIPTION
## 📌 Summary
Fixed the issue where customer order was inconsistent after page reload (newest first). Now sorting customers by `created_at ASC` (oldest first) to match the frontend "append" behavior.

## 🔗 Related Issue
Closes #90 

## 🧠 What was done?
- [x] Modified `backend/app/services/customer_service.py`
- [x] Changed sorting logic from `reverse=True` (DESC) to default (ASC).

## 🔧 Technical Details
**Fix:**
\`\`\`python
# Before
customers.sort(key=lambda x: x.created_at, reverse=True)

# After
customers.sort(key=lambda x: x.created_at)  # Oldest first
\`\`\`

## 🧪 How was it tested?
- [x] Added new customer -> appears at end.
- [x] Refreshed page -> customer still at end.
- [x] Checked existing customers -> order preserved (oldest to newest).

## 📂 Affected Areas
- [x] Backend - Services (`customer_service.py`)

## ✅ Checklist
- [x] BRANCHING.md kurallarına uygun branch kullandım (`fix/customer-sorting-persistence`)
- [x] All acceptance criteria from issue #90  met