### PR TITLE
Feature/frontend date validation

### DIFF
--- a/frontend/src/components/CampaignModal.jsx
+++ b/frontend/src/components/CampaignModal.jsx
@@ -51,10 +51,12 @@ const CampaignModal = ({ isOpen, onClose, onSave, campaign, customers = [], lock
     const validateDates = (start, end) => {
         const today = getLocalDateString(0);
 
-        // Rule 1: Start date must be today or future (only for new campaigns or if date changed)
-        // Note: For editing existing campaigns, we might want to allow past dates if they were already set.
-        // But for "Yeni Kampanya", strictly >= today.
-        if (!campaign && start < today) {
+        // Rule 1: Start date must be today or future
+        // Note: For editing existing campaigns, allow past dates ONLY if it matches the original start date.
+        // (i.e. we can't change it to a DIFFERENT past date, but we can keep the existing one)
+        const originalStart = campaign?.start_date?.split('T')[0];
+
+        if (start < today && start !== originalStart) {
             return "Başlangıç tarihi geçmişte olamaz.";
         }
 
@@ -175,7 +177,7 @@ const CampaignModal = ({ isOpen, onClose, onSave, campaign, customers = [], lock
                                 className="w-full px-4 py-2.5 rounded-xl border border-slate-200 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all text-slate-900"
                                 value={formData.start_date}
                                 onChange={(e) => setFormData({ ...formData, start_date: e.target.value })}
-                                min={!campaign ? getLocalDateString(0) : undefined}
+                                min={getLocalDateString(0)}
                                 required
                             />
                         </div>


### PR DESCRIPTION
## 📌 Summary
Added validation logic to Campaign Modal to ensure start dates are future/today and end dates are strictly after start dates. improved UX by preventing selection of past dates in the calendar.

## 🔗 Related Issue
Closes #92 

## 🧠 What was done?
- [x] Updated `CampaignModal.jsx`.
- [x] Added validation: `startDate < today` (Invalid for new campaigns).
- [x] Added validation: `endDate <= startDate` (Invalid).
- [x] Added logic to preserve existing past dates during edit, but prevent changing to *new* past dates.
- [x] Added `min={today}` attribute to date inputs to block past date selection in UI.

## 🔧 Technical Details
- Uses local timezone for date comparison to fix "yesterday" bug.
- Default start date is set to local Today.

## 🧪 How was it tested?
- [x] Tried to save past date -> Blocked.
- [x] Tried to save end date before start date -> Blocked.
- [x] Verified calendar picker grays out past dates.
- [x] Verified editing an old campaign preserves its date unless changed.

## 📂 Affected Areas
- [x] Frontend - `CampaignModal.jsx`

## ✅ Checklist
- [ ] BRANCHING.md follows `feature/frontend-date-validation`
- [ ] All acceptance criteria from issue #92 met