### PR TITLE
Feature/fix analytics trend

### DIFF
--- a/backend/app/services/campaign_service.py
+++ b/backend/app/services/campaign_service.py
@@ -298,7 +298,6 @@ class CampaignService:
         return {
             "total_campaigns": total_campaigns,
             "this_month_count": this_month_count,
-            "last_month_count": last_month_count,
             "trend": trend,
             "trend_label": trend_label
         }


### PR DESCRIPTION
## 📌 Summary
Updated the "Total Campaigns" trend calculation in the analytics service.
Previously, it compared "This Month's Created" vs "Last Month's Created" (e.g., 1 vs 8 -> -87%), which misled users.
Now, it calculates **Growth Percentage**: `(New Campaigns This Month) / (Total Campaigns at Start of Month)`.

## 🔗 Related Issue
Closes #104

## 🧠 What was done?
- [x] Modified `get_campaign_stats` in `campaign_service.py`.
- [x] Changed trend logic:
    - Old: `(this_month - last_month) / last_month`
    - New: `this_month / (total - this_month)`
- [x] Updated trend label to "Geçen aya göre artış" (Growth vs last month).

## 🧪 How was it tested?
- [x] Verified calculation: If Total=9 and This Month=1, Start was 8. Growth = 1/8 = 12.5% (+12%).
- [x] Verified 0 division handling (if no campaigns existed before this month, trend is +100%).

## 📂 Affected Areas
- [ ] Backend - `app/services/campaign_service.py`

## ✅ Checklist
- [ ] BRANCHING.md follows `feature/fix-analytics-trend`
- [ ] All acceptance criteria from issue #104 met