### PR TITLE
feat(backend): implement sms refinement endpoint

### DIFF
--- a/backend/app/controllers/sms_controller.py
+++ b/backend/app/controllers/sms_controller.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
-from app.models.request_models import SMSRequest
-from app.models.response_models import SMSResponse
+from app.models.request_models import SMSRequest, RefineRequest
+from app.models.response_models import SMSResponse, SMSDraft
 from app.services.sms_service import SMSService
 
 router = APIRouter()
@@ -10,5 +10,12 @@ sms_service = SMSService()
 async def generate_sms(request: SMSRequest):
     try:
         return await sms_service.generate_campaign_drafts(request)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/refine-sms", response_model=SMSDraft)
+async def refine_sms(request: RefineRequest):
+    try:
+        return await sms_service.refine_sms_draft(request)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/models/request_models.py
+++ b/backend/app/models/request_models.py
@@ -1,5 +1,12 @@
 from pydantic import BaseModel, HttpUrl
 from typing import List, Optional
+from enum import Enum
+
+class RefinementType(str, Enum):
+    SHORTEN = "SHORTEN"
+    CLARIFY = "CLARIFY"
+    MORE_EXCITING = "MORE_EXCITING"
+    MORE_FORMAL = "MORE_FORMAL"
 
 class SMSRequest(BaseModel):
     website_url: str
@@ -23,3 +30,7 @@ class SMSRequest(BaseModel):
                 "target_audience": "Gençler, Moda Severler"
             }
         }
+
+class RefineRequest(BaseModel):
+    content: str
+    refinement_type: RefinementType


### PR DESCRIPTION
## 📌 Summary
Created API endpoint for SMS refinement (Shorten, Clarify, etc.).

## 🔗 Related Issue
Closes #110 

## 🧠 What was done?
- [ ] Created `POST /api/sms/refine` endpoint
- [ ] Implemented Gemini refinement prompt logic
- [ ] Added `RefinementRequest` model

## 🧪 How was it tested?
- [ ] Tested all refinement types (shorter, clearer, etc.) via Swagger
- [ ] Verified character count reduction for "Kısalt"

## ✅ Checklist
- [ ] BRANCHING.md kurallarına uygun branch (`feature/backend-refinement-api`)
- [ ] Auth middleware applied